### PR TITLE
Updating "The Role of Theory in Data Analysis" link

### DIFF
--- a/opinionated-practices-for-teaching-reproducibility-talk.Rmd
+++ b/opinionated-practices-for-teaching-reproducibility-talk.Rmd
@@ -382,7 +382,7 @@ class: center, middle
 
 class: middle
 
-### Excerpt from Roger Peng's blog post on <br> ["The Role of Theory in Data Analysis"](https://simplystatistics.org/2018/12/11/the-role-of-theory-in-data-analysis/):
+### Excerpt from Roger Peng's blog post on <br> ["The Role of Theory in Data Analysis"](https://simplystatistics.org/posts/2018-12-11-the-role-of-theory-in-data-analysis/):
 
 #### *There is no need for a new data analyst to learn about reproducibility “from experience”. We don’t need to lead a junior data analyst down a months-long winding path of non-reproducible analyses until they are finally bitten by non-reproducibility (and therefore “learn their lesson”). We can just tell them*
 

--- a/opinionated-practices-for-teaching-reproducibility-talk.html
+++ b/opinionated-practices-for-teaching-reproducibility-talk.html
@@ -369,7 +369,7 @@ class: center, middle
 
 class: middle
 
-### Excerpt from Roger Peng's blog post on &lt;br&gt; ["The Role of Theory in Data Analysis"](https://simplystatistics.org/2018/12/11/the-role-of-theory-in-data-analysis/):
+### Excerpt from Roger Peng's blog post on &lt;br&gt; ["The Role of Theory in Data Analysis"](https://simplystatistics.org/posts/2018-12-11-the-role-of-theory-in-data-analysis/):
 
 #### *There is no need for a new data analyst to learn about reproducibility “from experience”. We don’t need to lead a junior data analyst down a months-long winding path of non-reproducible analyses until they are finally bitten by non-reproducibility (and therefore “learn their lesson”). We can just tell them*
 


### PR DESCRIPTION
Hello!

I was going through the [published version of these slides](https://ttimbers.github.io/opinionated-practices-for-teaching-reproducibility-talk/opinionated-practices-for-teaching-reproducibility-talk.html#1) on `ttimbers.github.io` and the link to ["The Role of Theory in Data Analysis"](https://simplystatistics.org/2018/12/11/the-role-of-theory-in-data-analysis/) gave me a 404.

I poked around further on simplystatistics.org and found the new URL for that post [here](https://simplystatistics.org/posts/2018-12-11-the-role-of-theory-in-data-analysis/).

It looks like the `ttimbers.github.io` repo isn't public so I'm making the PR here instead. I manually edited both the R markdown and HTML files since it seemed like a straightforward string replacement, but I won't be offended if you close this PR and use a different editing workflow instead.

Thanks!